### PR TITLE
Add option to change consul binary version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Consul Puppet module for Octopus Energy
 
 ## Change log
 
+### v2.2
+
+- Add option for controlling the version of the consul binary downloaded
+
 ### v2.1
 
 - Add module tooling

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,15 +4,16 @@ class octo_consul (
   $datacenter = 'eu-west-1',
   $data_dir = '/opt/consul',
   $init_style = 'upstart',
+  $version = '0.5.2',
 ) {
   package { 'zip':
     ensure => installed,
   }
-
   # We set service_ensure to 'stopped' to avoid Consul starting up when
   # provisioning the AMI. If it does, then it sets the cluster IP address
   # which causes a problem when a new server is built using the AMI.
   class { 'consul':
+    version        => $version,
     service_ensure => 'stopped',
     config_hash    => {
       'data_dir'   => $data_dir,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "octoenergy-octo_consul",
-  "version": "2.1",
+  "version": "2.2",
   "author": "Octopus Energy",
   "license": "BSD",
   "summary": "Consul wrapper for Octopus Energy",


### PR DESCRIPTION
This PR allows us to change the version of the consul binary.

This change was needed to facilitate services running older versions of consul